### PR TITLE
Fix loss of pearlescentColor in SetVehicleProperties

### DIFF
--- a/client/functions.lua
+++ b/client/functions.lua
@@ -765,7 +765,7 @@ ESX.Game.SetVehicleProperties = function(vehicle, props)
 		if props.color1 then SetVehicleColours(vehicle, props.color1, colorSecondary) end
 		if props.color2 then SetVehicleColours(vehicle, props.color1 or colorPrimary, props.color2) end
 		if props.pearlescentColor then SetVehicleExtraColours(vehicle, props.pearlescentColor, wheelColor) end
-		if props.wheelColor then SetVehicleExtraColours(vehicle, pearlescentColor, props.wheelColor) end
+		if props.wheelColor then SetVehicleExtraColours(vehicle, props.pearlescentColor or pearlescentColor, props.wheelColor) end
 		if props.wheels then SetVehicleWheelType(vehicle, props.wheels) end
 		if props.windowTint then SetVehicleWindowTint(vehicle, props.windowTint) end
 


### PR DESCRIPTION
When wheelColor is set, the pearlescentColor is reset back to the same as the vehicle had at spawn or when the props are set rather than the defined prop value.